### PR TITLE
feat: upgrade nexus and gh auth plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM quay.io/travelaudience/docker-nexus:3.21.2-03
+# XXX: https://github.com/travelaudience/docker-nexus/pull/47
+# FROM quay.io/travelaudience/docker-nexus:3.21.2-03
+FROM caarlos0/nexus:3.24.0
 
 ENV GITHUB_ORG=''
 
-RUN mkdir -p /opt/sonatype/nexus/system/com/larscheidschmitzhermes/ &&\
-    wget -O /opt/sonatype/nexus/system/com/larscheidschmitzhermes/nexus3-github-oauth-plugin.zip https://github.com/larscheid-schmitzhermes/nexus3-github-oauth-plugin/releases/download/2.0.2/nexus3-github-oauth-plugin.zip &&\
-    unzip /opt/sonatype/nexus/system/com/larscheidschmitzhermes/nexus3-github-oauth-plugin.zip -d /opt/sonatype/nexus/system/com/larscheidschmitzhermes/ &&\
-    echo "mvn\:com.larscheidschmitzhermes/nexus3-github-oauth-plugin/2.0.2 = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
+RUN wget -O /opt/sonatype/nexus/deploy/nexus3-github-oauth-plugin.kar https://github.com/larscheid-schmitzhermes/nexus3-github-oauth-plugin/releases/download/3.1.0/nexus3-github-oauth-plugin.kar
+
 COPY run /etc/service/nexus/run

--- a/run
+++ b/run
@@ -5,6 +5,6 @@ find /nexus-data   ! \( -user nexus -and -group nexus \) -exec chown nexus:nexus
 
 if [[ -n "${GITHUB_ORG}" ]]; then
   echo "Setting github.org=${GITHUB_ORG} on /opt/sonatype/nexus/etc/githuboauth.properties"
-  echo "github.org=${GITHUB_ORG}" > /opt/sonatype/nexus/etc/githuboauth.properties
+  echo "github.org=${GITHUB_ORG}" >/opt/sonatype/nexus/etc/githuboauth.properties
 fi
 su-exec nexus /opt/sonatype/nexus/bin/nexus run


### PR DESCRIPTION
[Nexus upgrade to 3.23.0 is required for `npm audit` to work](https://help.sonatype.com/repomanager3/release-notes#ReleaseNotes-NexusRepositoryManager3.23.0). Since we're upgrading, bumped to latest (3.24.0).

Also upgraded the plugin, [which can now be installed in the `kar` format](https://github.com/larscheid-schmitzhermes/nexus3-github-oauth-plugin#installation).

refs https://github.com/travelaudience/docker-nexus/pull/47
refs https://github.com/totvslabs/infra/issues/3920